### PR TITLE
Ontop Protege Plugin

### DIFF
--- a/update-info/5.0.0/plugins.repository
+++ b/update-info/5.0.0/plugins.repository
@@ -31,6 +31,9 @@ http://jcel.sourceforge.net/update.properties
 // OntoGraf
 https://raw.githubusercontent.com/protegeproject/ontograf/master/update-info/protege-5/update.properties
 
+// Ontop
+https://github.com/ontop/ontop/raw/master/ontop-protege/update.properties
+
 // OWL2Query
 //http://krizik.felk.cvut.cz/km/owl2query/update.properties
 


### PR DESCRIPTION
Hi,

We have just released the 1.17 version of Ontop which is compatible with the latest version of Protege. We would like to make Ontop available from the protege plugin library.

Cheers,