### PR TITLE
Changed DL Learner plugin repository URL

### DIFF
--- a/update-info/5.0.0/plugins.repository
+++ b/update-info/5.0.0/plugins.repository
@@ -14,7 +14,7 @@ https://raw.githubusercontent.com/co-ode-owl-plugins/change-tracker/master/updat
 https://raw.githubusercontent.com/protegeproject/csv-export-plugin/master/src/main/resources/update.properties
 
 // DL Learner
-//https://raw.githubusercontent.com/AKSW/DL-Learner-Protege-Plugin/master/update.properties
+//https://raw.githubusercontent.com/SmartDataAnalytics/DL-Learner-Protege-Plugin/master/update.properties
 
 // DL Query
 https://raw.githubusercontent.com/protegeproject/dlquery/master/update-info/protege-5/update.properties


### PR DESCRIPTION
DL Learner plugin has moved to new Github organization, thus, we had to change the repository URL here