### PR TITLE
Update the url of Ontop plugin

### DIFF
--- a/update-info/5.0.0/plugins.repository
+++ b/update-info/5.0.0/plugins.repository
@@ -50,7 +50,7 @@ http://isbi.aau.at/ontodebug/update.properties
 https://kbss.felk.cvut.cz/tools/owlhierarchy/update.properties
 
 // Ontop
-https://github.com/ontop/ontop/raw/master/ontop-protege/update.properties
+https://github.com/ontop/ontop/raw/master/client/protege/update.properties
 
 // OWL2Query
 //http://krizik.felk.cvut.cz/km/owl2query/update.properties


### PR DESCRIPTION
Due to refactoring of the code base of Ontop, we need to update the URL of the Ontop Plugin. Could you help merge this request?