### PR TITLE
Add OBO taxon constraints plugin

### DIFF
--- a/update-info/5.0.0/plugins.repository
+++ b/update-info/5.0.0/plugins.repository
@@ -109,6 +109,9 @@ https://raw.githubusercontent.com/md-k-sarker/ROWL/master/update.properties
 //OBO Annotations Editor
 https://raw.githubusercontent.com/owlcollab/protege-obo-plugin/master/update.properties
 
+//OBO Taxon constraints plugin
+https://raw.githubusercontent.com/geneontology/protege-taxon-constraints/master/update.properties
+
 //OOPS! Evaluator
 //https://raw.githubusercontent.com/lukasged/oops-plugin/master/update.properties
 


### PR DESCRIPTION
This plugin aids OBO ontology developers to see the effective taxon constraints (e.g. `'in taxon' some Mammalia`)  for a selected concept.