### PR TITLE
update ontop plugin url

### DIFF
--- a/update-info/5.0.0/plugins.repository
+++ b/update-info/5.0.0/plugins.repository
@@ -59,7 +59,7 @@ http://isbi.aau.at/ontodebug/update.properties
 https://kbss.felk.cvut.cz/tools/owlhierarchy/update.properties
 
 // Ontop
-https://github.com/ontop/ontop/raw/master/client/protege/update.properties
+https://raw.githubusercontent.com/ontop/ontop/master/protege/plugin/update.properties
 
 // OWL2Query
 //http://krizik.felk.cvut.cz/km/owl2query/update.properties


### PR DESCRIPTION
The link of the Ontop plugin has been changed due to the re-organization of the code base. This PR fixes the url. 