### PR TITLE
New auto-update link for ELK with new release v0.6.0

### DIFF
--- a/update-info/5.0.0/plugins.repository
+++ b/update-info/5.0.0/plugins.repository
@@ -26,7 +26,7 @@ https://raw.githubusercontent.com/protegeproject/csv-export-plugin/master/src/ma
 https://raw.githubusercontent.com/protegeproject/dlquery/master/update-info/protege-5/update.properties
 
 // ELK
-https://raw.githubusercontent.com/protegeproject/autoupdate/master/elk/0.4.3/update.properties
+https://raw.githubusercontent.com/liveontologies/elk-reasoner/release/elk-distribution-parent/elk-distribution-protege/p5.update.properties
 
 // Existential Query
 https://raw.githubusercontent.com/protegeproject/existentialquery/master/update-info/protege-5/update.properties


### PR DESCRIPTION
See here:
https://github.com/liveontologies/elk-reasoner/releases/tag/v0.6.0